### PR TITLE
Add a note about Lavalink plugin support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A [Lavalink](https://github.com/freyacodes/Lavalink) plugin to support more audi
 
 To install this plugin either download the latest release and place it into your `plugins` folder or add the following into your `application.yml`
 
+For the moment, plugin support is an experimental Lavalink feature. To use this plugin, make sure you're using a [Lavalink build with plugin support](https://github.com/freyacodes/Lavalink/tree/feature/plugins).
+
 ```yaml
 lavalink:
   plugins:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A [Lavalink](https://github.com/freyacodes/Lavalink) plugin to support more audi
 
 To install this plugin either download the latest release and place it into your `plugins` folder or add the following into your `application.yml`
 
-For the moment, plugin support is an experimental Lavalink feature. To use this plugin, make sure you're using a [Lavalink build with plugin support](https://github.com/freyacodes/Lavalink/tree/feature/plugins).
+For the moment, plugin support is an experimental Lavalink feature. To use this plugin, make sure you're using a [Lavalink build with plugin support](https://github.com/freyacodes/Lavalink/tree/dev).
 
 ```yaml
 lavalink:


### PR DESCRIPTION
Just adding a small note about plugin support.
Perhaps I was just ill-informed, but I spent some time before I realised I needed a specific branch build of Lavalink to use the plugin.